### PR TITLE
KSV serialize key: slog::Key instead of &str

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -238,7 +238,7 @@ impl<W: io::Write> KSV<W> {
 }
 
 impl<W: io::Write> slog::Serializer for KSV<W> {
-    fn emit_arguments(&mut self, key: &str, val: &fmt::Arguments) -> slog::Result {
+    fn emit_arguments(&mut self, key: slog::Key, val: &fmt::Arguments) -> slog::Result {
         try!(write!(self.io, ", {}: {}", key, val));
         Ok(())
     }


### PR DESCRIPTION
This is a non-change for default features, but allows `slog-stdlog` to work with `slog`'s `dynamic-features` experimental feature as well.