### PR TITLE
add init_with_level function to pass log level explicitly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-stdlog"
-version = "3.0.3-pre"
+version = "3.0.4-pre"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "`log` crate adapter for slog-rs"
 keywords = ["slog", "logging", "json", "log"]


### PR DESCRIPTION
Signed-off-by: siddontang <siddontang@gmail.com>

We found that the log body will be evaluated even in `trace!`, see https://github.com/tikv/tikv/issues/3537

In the origin `init` function, it will use max level, we need to pass the log level explicitly to avoid the above problem. 

PTAL @dpc 