### PR TITLE
Set a default target on StdLog

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -233,7 +233,10 @@ impl slog::Drain for StdLog {
             slog::Level::Trace => log::LogLevel::Trace,
         };
 
-        let target = info.tag();
+        let mut target = info.tag();
+        if target.is_empty() {
+            target = info.module();
+        }
 
         let location = log::LogLocation {
             __module_path: info.module(),


### PR DESCRIPTION
>For cases where slog records don't have a tag set, use the same
>default target as the log crate's default target: the module path.