### PR TITLE
Log 0.4 support with unsafe lifetime extends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /tags
 /.cargo
 /rusty-tags.vi
+
+/.idea
+*.iml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "lib.rs"
 [dependencies]
 slog = "2"
 slog-scope = "4"
-log = { version = "0.4.6", features = ["std"] }
+log = { version = "0.4.8", features = ["std"] }
 crossbeam = "0.7.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/slog-stdlog"
 homepage = "https://github.com/slog-rs/stdlog"
 repository = "https://github.com/slog-rs/stdlog"
 readme = "README.md"
+edition = "2018"
 
 [lib]
 path = "lib.rs"
@@ -16,8 +17,8 @@ path = "lib.rs"
 [dependencies]
 slog = "2"
 slog-scope = "4"
-log = "0.3.6"
-crossbeam = "0.2.9"
+log = { version = "0.4.6", features = ["std"] }
+crossbeam = "0.7.1"
 
 [dev-dependencies]
 slog-term = "2"

--- a/lib.rs
+++ b/lib.rs
@@ -48,56 +48,57 @@
 //! ```
 #![warn(missing_docs)]
 
-#[macro_use]
-extern crate slog;
 extern crate log;
-extern crate slog_scope;
 
-use log::LogMetadata;
 use std::{fmt, io};
-
-use slog::Level;
-use slog::KV;
+use slog::{Level, KV, b};
 
 struct Logger;
 
-fn log_to_slog_level(level: log::LogLevel) -> Level {
+fn log_to_slog_level(level: log::Level) -> Level {
     match level {
-        log::LogLevel::Trace => Level::Trace,
-        log::LogLevel::Debug => Level::Debug,
-        log::LogLevel::Info => Level::Info,
-        log::LogLevel::Warn => Level::Warning,
-        log::LogLevel::Error => Level::Error,
+        log::Level::Trace => Level::Trace,
+        log::Level::Debug => Level::Debug,
+        log::Level::Info => Level::Info,
+        log::Level::Warn => Level::Warning,
+        log::Level::Error => Level::Error,
+    }
+}
+
+fn record_as_location(r: &log::Record) -> slog::RecordLocation {
+    let module = r.module_path().unwrap_or("<unknown>");
+    let file = r.file().unwrap_or("<unknown>");
+    let line = r.line().unwrap_or_default();
+
+    slog::RecordLocation {
+        file: unsafe { &*(file as *const _) }, // Lifetime extending for initially static ref
+        line,
+        column: 0,
+        function: "",
+        module: unsafe { &*(module as *const _) }, // Lifetime extending for initially static ref
     }
 }
 
 impl log::Log for Logger {
-    fn enabled(&self, _: &LogMetadata) -> bool {
+    fn enabled(&self, _: &log::Metadata) -> bool {
         true
     }
 
-    fn log(&self, r: &log::LogRecord) {
+    fn log(&self, r: &log::Record) {
         let level = log_to_slog_level(r.metadata().level());
 
         let args = r.args();
         let target = r.target();
-        let module = r.location().__module_path;
-        let file = r.location().__file;
-        let line = r.location().line();
-
+        let location = &record_as_location(r);
         let s = slog::RecordStatic {
-            location: &slog::RecordLocation {
-                file: file,
-                line: line,
-                column: 0,
-                function: "",
-                module: module,
-            },
-            level: level,
+            location,
+            level,
             tag: target,
         };
         slog_scope::with_logger(|logger| logger.log(&slog::Record::new(&s, args, b!())))
     }
+
+    fn flush(&self) {}
 }
 
 /// Register `slog-stdlog` as `log` backend.
@@ -130,11 +131,11 @@ impl log::Log for Logger {
 /// }
 /// ```
 pub fn init() -> Result<(), log::SetLoggerError> {
-    init_with_level(log::LogLevel::max())
+    init_with_level(log::Level::max())
 }
 
 /// Register `slog-stdlog` as `log` backend.
-/// Pass a log::LogLevel to do the log filter explicitly.
+/// Pass a log::Level to do the log filter explicitly.
 ///
 /// This will pass all logging statements crated with `log`
 /// crate to current `slog-scope::logger()`.
@@ -158,17 +159,17 @@ pub fn init() -> Result<(), log::SetLoggerError> {
 ///     let logger = slog::Logger::root(drain, slog_o!("version" => env!("CARGO_PKG_VERSION")));
 ///
 ///     let _scope_guard = slog_scope::set_global_logger(logger);
-///     let _log_guard = slog_stdlog::init_with_level(log::LogLevel::Error).unwrap();
+///     let _log_guard = slog_stdlog::init_with_level(log::Level::Error).unwrap();
 ///     // Note: this `info!(...)` macro comes from `log` crate
 ///     info!("standard logging redirected to slog");
 ///     error!("standard logging redirected to slog");
 /// }
 /// ```
-pub fn init_with_level(level: log::LogLevel) -> Result<(), log::SetLoggerError> {
-    log::set_logger(|max_log_level| {
-        max_log_level.set(level.to_log_level_filter());
-        Box::new(Logger)
-    })
+pub fn init_with_level(level: log::Level) -> Result<(), log::SetLoggerError> {
+    log::set_boxed_logger(Box::new(Logger))?;
+    log::set_max_level(level.to_level_filter());
+
+    Ok(())
 }
 
 /// Drain logging `Record`s into `log` crate
@@ -192,28 +193,26 @@ struct LazyLogString<'a> {
 impl<'a> LazyLogString<'a> {
     fn new(info: &'a slog::Record, logger_values: &'a slog::OwnedKVList) -> Self {
         LazyLogString {
-            info: info,
-            logger_values: logger_values,
+            info,
+            logger_values,
         }
     }
 }
 
 impl<'a> fmt::Display for LazyLogString<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "{}", self.info.msg()));
+        write!(f, "{}", self.info.msg())?;
 
         let io = io::Cursor::new(Vec::new());
         let mut ser = KSV::new(io);
 
-        let res = {
-            || -> io::Result<()> {
-                try!(self.logger_values.serialize(self.info, &mut ser));
-                try!(self.info.kv().serialize(self.info, &mut ser));
-                Ok(())
-            }
-        }().map_err(|_| fmt::Error);
-
-        try!(res);
+        self.logger_values
+            .serialize(self.info, &mut ser)
+            .map_err(|_| fmt::Error)?;
+        self.info
+            .kv()
+            .serialize(self.info, &mut ser)
+            .map_err(|_| fmt::Error)?;
 
         let values = ser.into_inner().into_inner();
 
@@ -222,15 +221,16 @@ impl<'a> fmt::Display for LazyLogString<'a> {
 }
 
 impl slog::Drain for StdLog {
-    type Err = io::Error;
     type Ok = ();
+    type Err = io::Error;
+
     fn log(&self, info: &slog::Record, logger_values: &slog::OwnedKVList) -> io::Result<()> {
         let level = match info.level() {
-            slog::Level::Critical | slog::Level::Error => log::LogLevel::Error,
-            slog::Level::Warning => log::LogLevel::Warn,
-            slog::Level::Info => log::LogLevel::Info,
-            slog::Level::Debug => log::LogLevel::Debug,
-            slog::Level::Trace => log::LogLevel::Trace,
+            slog::Level::Critical | slog::Level::Error => log::Level::Error,
+            slog::Level::Warning => log::Level::Warn,
+            slog::Level::Info => log::Level::Info,
+            slog::Level::Debug => log::Level::Debug,
+            slog::Level::Trace => log::Level::Trace,
         };
 
         let mut target = info.tag();
@@ -238,16 +238,10 @@ impl slog::Drain for StdLog {
             target = info.module();
         }
 
-        let location = log::LogLocation {
-            __module_path: info.module(),
-            __file: info.file(),
-            __line: info.line(),
-        };
-
         let lazy = LazyLogString::new(info, logger_values);
         // Please don't yell at me for this! :D
         // https://github.com/rust-lang-nursery/log/issues/95
-        log::__log(level, target, &location, format_args!("{}", lazy));
+        log::__private_api_log(format_args!("{}", lazy), level, &(target, info.module(), info.file(), info.line()));
 
         Ok(())
     }
@@ -270,7 +264,7 @@ impl<W: io::Write> KSV<W> {
 
 impl<W: io::Write> slog::Serializer for KSV<W> {
     fn emit_arguments(&mut self, key: slog::Key, val: &fmt::Arguments) -> slog::Result {
-        try!(write!(self.io, ", {}: {}", key, val));
+        write!(self.io, ", {}: {}", key, val)?;
         Ok(())
     }
 }

--- a/lib.rs
+++ b/lib.rs
@@ -66,16 +66,16 @@ fn log_to_slog_level(level: log::Level) -> Level {
 }
 
 fn record_as_location(r: &log::Record) -> slog::RecordLocation {
-    let module = r.module_path().unwrap_or("<unknown>");
-    let file = r.file().unwrap_or("<unknown>");
+    let module = r.module_path_static().unwrap_or("<unknown>");
+    let file = r.file_static().unwrap_or("<unknown>");
     let line = r.line().unwrap_or_default();
 
     slog::RecordLocation {
-        file: unsafe { &*(file as *const _) }, // Lifetime extending for initially static ref
+        file,
         line,
         column: 0,
         function: "",
-        module: unsafe { &*(module as *const _) }, // Lifetime extending for initially static ref
+        module,
     }
 }
 


### PR DESCRIPTION
This PR contains updates to support log 0.4, and potentially (?) problem code:

```rust
fn record_as_location(r: &log::Record) -> slog::RecordLocation {
    let module = r.module_path().unwrap_or("<unknown>");
    let file = r.file().unwrap_or("<unknown>");
    let line = r.line().unwrap_or_default();

    slog::RecordLocation {
        file: unsafe { &*(file as *const _) }, // Lifetime extending for initially static ref
        line,
        column: 0,
        function: "",
        module: unsafe { &*(module as *const _) }, // Lifetime extending for initially static ref
    }
}
```

We can remove this unsafe code only after change the lifetime parameter in the `slog::RecordLocation` type.