### PR TITLE
bump version to 3.0.5 since -pre suffix seems to break on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-stdlog"
-version = "3.0.4-pre"
+version = "3.0.5"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "`log` crate adapter for slog-rs"
 keywords = ["slog", "logging", "json", "log"]


### PR DESCRIPTION
Hi!

It seems like crates.io (https://crates.io/crates/slog-stdlog) is unhappy with 3.0.4-pre. While it is aware of it, as seen below:
![image](https://user-images.githubusercontent.com/1485066/61827874-68ac0f00-ae1a-11e9-935a-f748fb838731.png)

It thinks the most recent version is 3.0.2:
![image](https://user-images.githubusercontent.com/1485066/61827898-71044a00-ae1a-11e9-9b46-8d3253ac6751.png)

Releasing 3.0.5 should fix that, I believe.

Thanks!