### PR TITLE
Require slog 2.4 or greater

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 path = "lib.rs"
 
 [dependencies]
-slog = "2"
+slog = "2.4"
 slog-scope = "4"
 log = { version = "0.4.8", features = ["std"] }
 crossbeam = "0.7.1"


### PR DESCRIPTION
`lib.rs` uses Rust 2018 style macro imports to import `b!`, which depends on
`kv!`, however `slog` only defined kv! using `local_inner_macros` from `2.4.0`
so `slog-stdlog` will fail to compile against versions of `slog` prior to
`2.4.0`.