### PR TITLE
Add support to log == 0.4.10.

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -241,7 +241,7 @@ impl slog::Drain for StdLog {
         let lazy = LazyLogString::new(info, logger_values);
         // Please don't yell at me for this! :D
         // https://github.com/rust-lang-nursery/log/issues/95
-        log::__private_api_log(format_args!("{}", lazy), level, &(target, info.module(), info.file(), info.line()));
+        log::__private_api_log(format_args!("{}", lazy), level, &(target, info.module(), info.file(), info.line()), None);
 
         Ok(())
     }


### PR DESCRIPTION
This commit update signature of private log api, changed in log crate version 0.4.10.