### PR TITLE
Remove unused dependency `crossbeam = 0.7.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ path = "lib.rs"
 slog = "2.4"
 slog-scope = "4"
 log = { version = "0.4.10", features = ["std"] }
-crossbeam = "0.7.1"
 
 [dev-dependencies]
 slog-term = "2"


### PR DESCRIPTION
Hi! I happened to notice that `crossbeam` is not used in this crate; this PR should help clean up the Cargo.toml a little.