### PR TITLE
fix compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "lib.rs"
 [dependencies]
 slog = "2.4"
 slog-scope = "4"
-log = { version = "0.4.10", features = ["std"] }
+log = { version = "0.4.11", features = ["std"] }
 
 [dev-dependencies]
 slog-term = "2"

--- a/lib.rs
+++ b/lib.rs
@@ -241,7 +241,7 @@ impl slog::Drain for StdLog {
         let lazy = LazyLogString::new(info, logger_values);
         // Please don't yell at me for this! :D
         // https://github.com/rust-lang-nursery/log/issues/95
-        log::__private_api_log(format_args!("{}", lazy), level, &(target, info.module(), info.file(), info.line()), None);
+        log::__private_api_log(format_args!("{}", lazy), level, &(target, info.module(), info.file(), info.line()));
 
         Ok(())
     }


### PR DESCRIPTION
Just fix the compilation.
A minor version update is needed as the 4.0.0 version has useless dependency on crossbeam.