### PR TITLE
Add feature flag to minimize RecordLocation unknowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.2.0 - 2021-7-12
+### Changed
+
+* Add feature flag `record_location_unstable` to expand record location support.
+  Be warned that this is accomplished by leaking the record location strings.
+
+## 4.1.0 - 2020-10-21
+### Changed
+
+* Require `slog` 2.4 or greater
+* Remove dependency `crossbeam`
+* Require `log` 0.4.11 or greater
+
 ## 4.0.0 - 2018-08-13
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-stdlog"
-version = "4.1.0"
+version = "4.2.0"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "`log` crate adapter for slog-rs"
 keywords = ["slog", "logging", "json", "log"]
@@ -17,6 +17,7 @@ path = "lib.rs"
 [features]
 default = []
 kv_unstable = ["log/kv_unstable_std", "slog/dynamic-keys"]
+record_location_unstable = []
 
 [dependencies]
 slog = "2.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ path = "lib.rs"
 [features]
 default = []
 kv_unstable = ["log/kv_unstable_std", "slog/dynamic-keys"]
-record_location_unstable = []
+record_location_unstable = ["cached"]
 
 [dependencies]
 slog = "2.4"
 slog-scope = "4"
 log = { version = "0.4.11", features = ["std"] }
-cached = "0.23.0"
+cached = { version = "0.23.0", optional = true }
 
 [dev-dependencies]
 slog-term = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ record_location_unstable = []
 slog = "2.4"
 slog-scope = "4"
 log = { version = "0.4.11", features = ["std"] }
+cached = "0.23.0"
 
 [dev-dependencies]
 slog-term = "2"

--- a/lib.rs
+++ b/lib.rs
@@ -53,8 +53,8 @@ extern crate log;
 #[cfg(feature = "kv_unstable")]
 mod kv;
 
+use slog::{b, Level, KV};
 use std::{fmt, io};
-use slog::{Level, KV, b};
 
 struct Logger;
 
@@ -69,7 +69,21 @@ fn log_to_slog_level(level: log::Level) -> Level {
 }
 
 fn record_as_location(r: &log::Record) -> slog::RecordLocation {
+    // Warning: expands Record module and file names for non-static strings by leaking strings
+    #[cfg(feature = "record_location_unstable")]
+    let module = r.module_path_static().unwrap_or(match r.module_path() {
+        Some(s) => Box::leak(s.to_string().into_boxed_str()),
+        None => "unknown",
+    });
+    #[cfg(feature = "record_location_unstable")]
+    let file = r.file_static().unwrap_or(match r.file() {
+        Some(s) => Box::leak(s.to_string().into_boxed_str()),
+        None => "unknown",
+    });
+
+    #[cfg(not(feature = "record_location_unstable"))]
     let module = r.module_path_static().unwrap_or("<unknown>");
+    #[cfg(not(feature = "record_location_unstable"))]
     let file = r.file_static().unwrap_or("<unknown>");
     let line = r.line().unwrap_or_default();
 
@@ -100,10 +114,10 @@ impl log::Log for Logger {
         };
         #[cfg(feature = "kv_unstable")]
         {
-             let key_values = r.key_values();
-             let mut visitor = kv::Visitor::new();
-             key_values.visit(&mut visitor).unwrap();
-             slog_scope::with_logger(|logger| logger.log(&slog::Record::new(&s, args, b!(visitor))))
+            let key_values = r.key_values();
+            let mut visitor = kv::Visitor::new();
+            key_values.visit(&mut visitor).unwrap();
+            slog_scope::with_logger(|logger| logger.log(&slog::Record::new(&s, args, b!(visitor))))
         }
         #[cfg(not(feature = "kv_unstable"))]
         slog_scope::with_logger(|logger| logger.log(&slog::Record::new(&s, args, b!())))
@@ -252,7 +266,11 @@ impl slog::Drain for StdLog {
         let lazy = LazyLogString::new(info, logger_values);
         // Please don't yell at me for this! :D
         // https://github.com/rust-lang-nursery/log/issues/95
-        log::__private_api_log(format_args!("{}", lazy), level, &(target, info.module(), info.file(), info.line()));
+        log::__private_api_log(
+            format_args!("{}", lazy),
+            level,
+            &(target, info.module(), info.file(), info.line()),
+        );
 
         Ok(())
     }

--- a/lib.rs
+++ b/lib.rs
@@ -114,10 +114,10 @@ impl log::Log for Logger {
         };
         #[cfg(feature = "kv_unstable")]
         {
-            let key_values = r.key_values();
-            let mut visitor = kv::Visitor::new();
-            key_values.visit(&mut visitor).unwrap();
-            slog_scope::with_logger(|logger| logger.log(&slog::Record::new(&s, args, b!(visitor))))
+             let key_values = r.key_values();
+             let mut visitor = kv::Visitor::new();
+             key_values.visit(&mut visitor).unwrap();
+             slog_scope::with_logger(|logger| logger.log(&slog::Record::new(&s, args, b!(visitor))))
         }
         #[cfg(not(feature = "kv_unstable"))]
         slog_scope::with_logger(|logger| logger.log(&slog::Record::new(&s, args, b!())))
@@ -266,11 +266,7 @@ impl slog::Drain for StdLog {
         let lazy = LazyLogString::new(info, logger_values);
         // Please don't yell at me for this! :D
         // https://github.com/rust-lang-nursery/log/issues/95
-        log::__private_api_log(
-            format_args!("{}", lazy),
-            level,
-            &(target, info.module(), info.file(), info.line()),
-        );
+        log::__private_api_log(format_args!("{}", lazy), level, &(target, info.module(), info.file(), info.line()));
 
         Ok(())
     }


### PR DESCRIPTION
As proposed by @dpc [here](https://github.com/slog-rs/slog/issues/262), this PR allows non-static modules and files to come through slog by leaking the memory.

I decided to put this behind a feature flag because I don't think that people depending on this should be forced into this change. I called the feature flag `record_location_unstable` but would be open to naming suggestions.

Let me know if there are other changes I should make for this. Thank you very much!