### PR TITLE
Lock to log 0.4.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ kv_unstable = ["log/kv_unstable_std", "slog/dynamic-keys"]
 [dependencies]
 slog = "2.4"
 slog-scope = "4"
-log = { version = "0.4.11", features = ["std"] }
+# 0.4.15 and above change a private API slog-stdlog depends on. See https://github.com/slog-rs/slog/issues/309
+log = { version = "=0.4.14", features = ["std"] }
 
 [dev-dependencies]
 slog-term = "2"


### PR DESCRIPTION
This avoids a change to the `log` private API. There should probably be a better solution long term, but I think this is a reasonable workaround.

Error users will see without this change.
```
 --> lib.rs:255:9
     |
255  |         log::__private_api_log(format_args!("{}", lazy), level, &(target, info.module(), info.file(), info.line()));
     |         ^^^^^^^^^^^^^^^^^^^^^^ ------------------------  -----  -------------------------------------------------- supplied 3 arguments
     |         |
     |         expected 4 arguments
```

If this is merged, it would be nice to do a patch release as well. Thanks!