### PR TITLE
Release 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.1.0 - 2020-10-21
+### Changed
+
+* Require `slog>=2.4`
+* Require `log>=0.4.11
+
+## Fixed
+
+* Remove unused dependency `crossbeam = 0.7.1`
+
 ## 4.0.0 - 2018-08-13
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.1.1 - 2022-03-22
+### Added
+
+* Support `feature="log/kv-unstable"` (PR #18)
+  * Requires `slog/dynamic-keys`
+  * This is unstable (obviously), so I don't consider it
+    a change that warants a minor-version bump
+
+### Changed
+
+* Switch to github actions (PR #20)
+
+### Fixed
+
+* Avoid using log's private API to construct records (PR #21)
+  * Fixes recent versions of `log` crate (`>=0.4.15`), resolving slog-rs/slog#309
+* Fix formatting & clippy lints (part of switch to GH actions)
+
 ## 4.1.0 - 2020-10-21
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-stdlog"
-version = "4.1.0"
+version = "4.1.1"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "`log` crate adapter for slog-rs"
 keywords = ["slog", "logging", "json", "log"]


### PR DESCRIPTION

Adds CHANGELOG.md for 4.1.0 (last release)

Bump version to 4.1.1


Most important changes this release are fixing `log>=0.4.15`.
    
Adding the new feature (support for `log/unstable_kv`) could
arguably require bumping the minor version (-> 4.2.0)
    
However, since it's an unstable feature so I don't consider that necessary.

@dpc - Tell me if you disagree and I can do a minor version bump ;)
