### PR TITLE
Reduce allocations for kv from log to slog

### DIFF
--- a/kv.rs
+++ b/kv.rs
@@ -1,35 +1,82 @@
+use log::kv::value::Error as ValueError;
 use slog::{Record, Serializer};
 
-pub(crate) struct Visitor {
-    kvs: Vec<(String, String)>,
+struct Visitor<'s> {
+    serializer: &'s mut dyn Serializer,
 }
 
-impl Visitor {
-    pub fn new() -> Self {
-        Self { kvs: vec![] }
+impl<'s> Visitor<'s> {
+    pub fn new(serializer: &'s mut dyn Serializer) -> Self {
+        Self { serializer }
     }
 }
 
-impl<'kvs, 'a> log::kv::Visitor<'kvs> for Visitor {
+pub(crate) struct SourceKV<'kvs>(pub &'kvs dyn log::kv::source::Source);
+
+struct KeyVisit<'s> {
+    serializer: &'s mut dyn Serializer,
+    key: &'s str,
+}
+
+impl<'kvs> log::kv::Visitor<'kvs> for Visitor<'kvs> {
     fn visit_pair(
         &mut self,
         key: log::kv::Key<'kvs>,
         val: log::kv::Value<'kvs>,
     ) -> Result<(), log::kv::Error> {
-        let key = key.to_string();
-        if let Some(val) = val.to_borrowed_str() {
-            let val = val.to_string();
-            self.kvs.push((key, val));
-        }
-        Ok(())
+        val.visit(KeyVisit {
+            serializer: self.serializer,
+            key: key.as_str(),
+        })
     }
 }
 
-impl slog::KV for Visitor {
-    fn serialize(&self, _record: &Record, serializer: &mut dyn Serializer) -> slog::Result {
-        for (key, val) in &self.kvs {
-            serializer.emit_str(key.to_owned().into(), val.as_str())?;
+macro_rules! visit_to_emit {
+    ($t:ty : $vname:ident -> $ename:ident) => {
+        fn $vname(&mut self, value: $t) -> Result<(), ValueError> {
+            self.serializer
+                .$ename(self.key.to_string().into(), value)
+                .map_err(to_value_err)
         }
-        Ok(())
+    };
+}
+
+impl<'s> log::kv::value::Visit<'s> for KeyVisit<'s> {
+    fn visit_any(&mut self, value: log::kv::Value<'_>) -> Result<(), ValueError> {
+        let key = self.key.to_string().into();
+        self.serializer
+            .emit_arguments(key, &format_args!("{}", value))
+            .map_err(to_value_err)
+    }
+
+    visit_to_emit!(u64: visit_u64 -> emit_u64);
+    visit_to_emit!(i64: visit_i64 -> emit_i64);
+    visit_to_emit!(u128: visit_u128 -> emit_u128);
+    visit_to_emit!(i128: visit_i128 -> emit_i128);
+    visit_to_emit!(f64: visit_f64 -> emit_f64);
+    visit_to_emit!(bool: visit_bool -> emit_bool);
+    visit_to_emit!(&str: visit_str -> emit_str);
+    visit_to_emit!(char: visit_char -> emit_char);
+    visit_to_emit!(&(dyn std::error::Error + 'static): visit_error -> emit_error);
+}
+
+impl slog::KV for SourceKV<'_> {
+    fn serialize(&self, _record: &Record, serializer: &mut dyn Serializer) -> slog::Result {
+        // Unfortunately, there isn't  a way for use to pass the original error through.
+        self.0
+            .visit(&mut Visitor::new(serializer))
+            .map_err(|_| slog::Error::Other)
     }
 }
+
+fn to_value_err(err: slog::Error) -> ValueError {
+    use slog::Error::*;
+
+    match err {
+        Io(e) => e.into(),
+        Fmt(e) => e.into(),
+        Other => ValueError::boxed(err),
+    }
+}
+
+// TODO: support going the other way

--- a/lib.rs
+++ b/lib.rs
@@ -100,10 +100,10 @@ impl log::Log for Logger {
         };
         #[cfg(feature = "kv_unstable")]
         {
-            let key_values = r.key_values();
-            let mut visitor = kv::Visitor::new();
-            key_values.visit(&mut visitor).unwrap();
-            slog_scope::with_logger(|logger| logger.log(&slog::Record::new(&s, args, b!(visitor))))
+            let key_values = kv::SourceKV(r.key_values());
+            slog_scope::with_logger(|logger| {
+                logger.log(&slog::Record::new(&s, args, b!(key_values)))
+            })
         }
         #[cfg(not(feature = "kv_unstable"))]
         slog_scope::with_logger(|logger| logger.log(&slog::Record::new(&s, args, b!())))


### PR DESCRIPTION
See: https://github.com/rust-lang/log/issues/328

This also preserves type information during the translation.